### PR TITLE
Feat/#18 이력서 기반 질문 API 구현 

### DIFF
--- a/src/main/java/techtrek/domain/sessionInfo/controller/SessionInfoController.java
+++ b/src/main/java/techtrek/domain/sessionInfo/controller/SessionInfoController.java
@@ -24,7 +24,7 @@ public class SessionInfoController {
         return ApiResponse.onSuccess(response);
     }
 
-    // 새 질문 불러오기
+    // 새로운 질문 불러오기
     @GetMapping("/questions/new/{sessionId}")
     public ResponseEntity<CommonResponse<SessionInfoResponse.NewQuestion>> getNewInterview(@PathVariable String sessionId) {
         SessionInfoResponse.NewQuestion response = sessionInfoService.getNewInterview(sessionId);

--- a/src/main/java/techtrek/domain/sessionInfo/dto/SessionInfoRequest.java
+++ b/src/main/java/techtrek/domain/sessionInfo/dto/SessionInfoRequest.java
@@ -3,6 +3,7 @@ package techtrek.domain.sessionInfo.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import techtrek.domain.sessionInfo.entity.status.EnterpriseName;
 import techtrek.domain.sessionInfo.entity.status.EnterpriseType;
 
 @Getter
@@ -14,7 +15,7 @@ public class SessionInfoRequest {
     @Setter
     @AllArgsConstructor
     public static class Start {
-        private String enterpriseName;
+        private EnterpriseName enterpriseName;
         private EnterpriseType enterpriseType;
     }
 

--- a/src/main/java/techtrek/domain/sessionInfo/entity/SessionInfo.java
+++ b/src/main/java/techtrek/domain/sessionInfo/entity/SessionInfo.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import jakarta.persistence.Id;
 import techtrek.domain.analysis.entity.Analysis;
+import techtrek.domain.sessionInfo.entity.status.EnterpriseName;
 import techtrek.domain.sessionInfo.entity.status.EnterpriseType;
 import techtrek.domain.user.entity.User;
 
@@ -23,8 +24,10 @@ public class SessionInfo {
     @Column(length = 255, nullable = false)
     private String sessionId;
 
-    @Column(length = 12, nullable = false)
-    private String enterpriseName;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EnterpriseName enterpriseName;
+
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/techtrek/domain/sessionInfo/entity/status/EnterpriseName.java
+++ b/src/main/java/techtrek/domain/sessionInfo/entity/status/EnterpriseName.java
@@ -1,0 +1,24 @@
+package techtrek.domain.sessionInfo.entity.status;
+
+
+public enum EnterpriseName {
+    삼성전자("전통 CS 기본기"),
+    쿠팡("대규모 트래픽, 인프라"),
+    네이버("웹 아키텍처 이해"),
+    카카오("설명력 중심 + 실무적 질문"),
+    배달의민족("실무 기반 시스템 설계, 최적화, 데이터 처리"),
+    당근마켓("최신 아키텍처 기반, 최적화, 데이터 처리"),
+    토스("Why 중심의 근본적 질문"),
+    넥슨( "게임 서버/동시성 특화");
+
+    private final String description;
+
+    EnterpriseName(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/src/main/java/techtrek/domain/sessionInfo/repository/SessionInfoRepository.java
+++ b/src/main/java/techtrek/domain/sessionInfo/repository/SessionInfoRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import techtrek.domain.sessionInfo.entity.SessionInfo;
 
+import java.util.Optional;
+
 @Repository
 public interface SessionInfoRepository extends JpaRepository<SessionInfo, String> {
+    Optional<SessionInfo> findBySessionId(String sessionId);
 }

--- a/src/main/java/techtrek/global/code/status/ResponseCode.java
+++ b/src/main/java/techtrek/global/code/status/ResponseCode.java
@@ -12,7 +12,8 @@ public enum ResponseCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 오류"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다"),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "USER409", "중복된 사용자 이름입니다"),
-    BASIC_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION404", "기본 질문을 찾을 수 없습니다");
+    BASIC_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION404", "기본 질문을 찾을 수 없습니다"),
+    SESSIONID_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION404", "세션ID를 찾을 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📌 관련 이슈
#18 


## ✨ 요약
사용자의 이력서 + 기업의 경향성을 토대로 cs 면접 질문하는 API


## 상세 내용 
enterpriseName을 String이 아닌, enum으로 변경
각 기업별 경향성 추가 


## 📸 스크린샷(선택)
<img width="758" alt="image" src="https://github.com/user-attachments/assets/8f0b2b7d-0c09-4e14-8ce8-6bf29702740b" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
