### PR TITLE
Feat/#22 꼬리질문 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'com.h2database:h2'  // H2 DB 의존성 추가
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis' // redis
 	implementation 'org.apache.pdfbox:pdfbox:2.0.29' // 자바 기반 PDF 파일 텍스트 추출
+	implementation 'org.json:json:20230227' //JSONException 라이브러리
 }
 
 

--- a/src/main/java/techtrek/domain/sessionInfo/controller/SessionInfoController.java
+++ b/src/main/java/techtrek/domain/sessionInfo/controller/SessionInfoController.java
@@ -32,6 +32,14 @@ public class SessionInfoController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 꼬리질문 불러오기
+    @PostMapping("/questions/tail")
+    public ResponseEntity<CommonResponse<SessionInfoResponse.NewQuestion>> createTailInterview(@RequestBody SessionInfoRequest.TailQuestion request) {
+        SessionInfoResponse.NewQuestion response = sessionInfoService.createTailInterview(request.getSessionId(), request.getParentId());
+
+        return ApiResponse.onSuccess(response);
+    }
+
     // 답변하기
     @PostMapping("/answers")
     public ResponseEntity<CommonResponse<Boolean>> createAnswer(@RequestBody SessionInfoRequest.Answer request) {

--- a/src/main/java/techtrek/domain/sessionInfo/dto/SessionInfoRequest.java
+++ b/src/main/java/techtrek/domain/sessionInfo/dto/SessionInfoRequest.java
@@ -28,4 +28,13 @@ public class SessionInfoRequest {
         private String type;
         private String answer;
     }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class TailQuestion {
+        private String sessionId;
+        private String parentId;
+    }
+
 }

--- a/src/main/java/techtrek/global/code/status/ResponseCode.java
+++ b/src/main/java/techtrek/global/code/status/ResponseCode.java
@@ -15,7 +15,7 @@ public enum ResponseCode {
     BASIC_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION500", "기본 질문을 찾을 수 없습니다"),
     ENTERPRISE_KEYWORDS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION500", "키워드를 찾을 수 없습니다."),
     CATEGORY_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION500", "키워드를 찾을 수 없습니다."),
-    SESSIONID_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION404", "세션ID를 찾을 수 없습니다");
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION404", "세션을 찾을 수 없습니다");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 관련 이슈
#22 


## ✨ 요약
이전 질문, 답변을 이용하여 gpt를 이용해 꼬리질문을 생성하였다. 


## 상세 내용 
**1. 새로운 질문은 `new` 파일, 꼬리질문은 `tail` 파일로 나누었다.**
</br>
그 이유는 다음과 같다:
- **기본 질문 로직**에서는 새로운 질문(`new`)이 5개씩 번갈아가며 *기본질문*과 *이력서 기반 질문*이 나오도록 설계되어 있다.
- 이때 **꼬리질문은 해당 5개의 개수에 포함되지 않는다.**
- 즉, 사용자가 꼬리질문을 아무리 많이 생성하더라도 `new` 질문의 개수에는 영향을 주지 않으며, 계속해서 꼬리질문을 추가할 수 있다.
- 이러한 구조를 명확하게 구분하기 위해 새로운 질문과 꼬리질문을 각각 `new`와 `tail` 파일로 분리하였다.
</br>
</br>
**2. 꼬리질문은 번호를 하이픈(1-1, 1-2 ...)으로 생성되게 구현하였다.** 
- UI에서 사용자가 꼬리질문인지 한눈에 보기 편하게 하기 위해 구분해주었다. 

</br>
</br>
## 📸 스크린샷(선택)
- 첫번째 질문에 대한 답변 (질문: 보이스코드 정규형의 조건을 설명해주세요. ) 
<img width="671" alt="image" src="https://github.com/user-attachments/assets/10ffb426-9fad-4a8c-915b-c0b55ad60ff3" />

</br>
- 꼬리질문 
<img width="675" alt="image" src="https://github.com/user-attachments/assets/9eb3bd74-81be-476c-8a36-9d6fe0172859" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!— 참고할 사항이 있다면 적어주세요 —>

